### PR TITLE
Compute moisture rmf as in official RothC26C3

### DIFF
--- a/pkg/R/fW.RothC.R
+++ b/pkg/R/fW.RothC.R
@@ -35,7 +35,8 @@ fW.RothC<-function(
      )
     {  
      B=ifelse(bare == FALSE,1,1.8)
-     Max.TSMD=-(20+1.3*pClay-0.01*(pClay^2))*(S.Thick/23)*(1/B)
+     Max.TSMD=-(20+1.3*pClay-0.01*(pClay^2))*(S.Thick/23)
+     TSMD.limit=Max.TSMD*(1/B)
      M=P-E*pE
      Acc.TSMD=NULL
        for(i in 2:length(M)){
@@ -44,8 +45,8 @@ fW.RothC<-function(
              Acc.TSMD[i]=Acc.TSMD[i-1]+M[i]
           }
             else(Acc.TSMD[i]=0)
-         if(Acc.TSMD[i]<=Max.TSMD) {
-            Acc.TSMD[i]=Max.TSMD
+         if(Acc.TSMD[i]<=TSMD.limit) {
+            Acc.TSMD[i]=TSMD.limit
          }
        }
      b=ifelse(test=Acc.TSMD > 0.444*Max.TSMD, # test uses < instead of > because values are negative


### PR DESCRIPTION
This commit fixes a discrepancy between the official RothC and SoilR implementation in the calculation of the soil moisture - rate modifyer (rmf) under bare soil.

In the official RothC implementation
(https://github.com/Rothamsted-Models/RothC_Code):

- maximum topsoil moisture deficit (Max.TSMD) is calculated from clay content and thickness of the topsoil,

- accumulated soil moisture deficit (Acc.TSMD) is limited to the bare soil moisture deficit (BareSMD = Max.TSMD / 1.8), and

- rate modifyer (beta) is calculated from Max.TSMD and Acc.TSMD.

In the SoilR implementation:

- Max.TSMD is calculated from clay content and thickness of the topsoil as in the official RothC implementation but set to Max.TSMD / 1.8 (= BareSMD),

- Acc.TSMD is limited to Max.TSMD, and - beta is calculated from Max.TSMD and Acc.TSMD,

which leads to wrong results.

In this commit:

- Max.TSMD and b are calculated as in the official RothC implementation, and

- Acc.TSMD is limited to TSMD.limit, which is Max.TSMD / 1.8 for bare and Max.TSMD for vegetated soil.